### PR TITLE
Disburse status with sub accounts

### DIFF
--- a/disbursement/client.go
+++ b/disbursement/client.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
-
+	
 	"github.com/xendit/xendit-go"
 	"github.com/xendit/xendit-go/utils/validator"
 )
@@ -64,13 +64,17 @@ func (c *Client) GetByIDWithContext(ctx context.Context, data *GetByIDParams) (*
 	}
 
 	response := &xendit.Disbursement{}
+	header := &http.Header{}
+	if data.ForUserID != "" {
+		header.Add("for-user-id", data.ForUserID)
+	}
 
 	err := c.APIRequester.Call(
 		ctx,
 		"GET",
 		fmt.Sprintf("%s/disbursements/%s", c.Opt.XenditURL, data.DisbursementID),
 		c.Opt.SecretKey,
-		nil,
+		header,
 		nil,
 		response,
 	)
@@ -93,13 +97,17 @@ func (c *Client) GetByExternalIDWithContext(ctx context.Context, data *GetByExte
 	}
 
 	response := []xendit.Disbursement{}
+	header := &http.Header{}
+	if data.ForUserID != "" {
+		header.Add("for-user-id", data.ForUserID)
+	}
 
 	err := c.APIRequester.Call(
 		ctx,
 		"GET",
 		fmt.Sprintf("%s/disbursements?%s", c.Opt.XenditURL, data.QueryString()),
 		c.Opt.SecretKey,
-		nil,
+		header,
 		nil,
 		&response,
 	)

--- a/disbursement/params.go
+++ b/disbursement/params.go
@@ -22,11 +22,13 @@ type CreateParams struct {
 // GetByIDParams contains parameters for GetByID
 type GetByIDParams struct {
 	DisbursementID string `json:"disbursement_id" validate:"required"`
+	ForUserID      string `json:"-"`
 }
 
 // GetByExternalIDParams contains parameters for GetByExternalID
 type GetByExternalIDParams struct {
 	ExternalID string `json:"external_id" validate:"required"`
+	ForUserID  string `json:"-"`
 }
 
 // QueryString creates query string from GetByExternalIDParams, ignores nil values


### PR DESCRIPTION
Currently there is no option for GET disburse status API to be called with sub-account status. This PR handles that case.