### PR TITLE
Expire an invoice belonging to a sub accounts

### DIFF
--- a/invoice/client.go
+++ b/invoice/client.go
@@ -90,13 +90,16 @@ func (c *Client) ExpireWithContext(ctx context.Context, data *ExpireParams) (*xe
 	}
 
 	response := &xendit.Invoice{}
-
+	header := &http.Header{}
+	if data.ForUserID != "" {
+		header.Add("for-user-id", data.ForUserID)
+	}
 	err := c.APIRequester.Call(
 		ctx,
 		"POST",
 		fmt.Sprintf("%s/invoices/%s/expire!", c.Opt.XenditURL, data.ID),
 		c.Opt.SecretKey,
-		nil,
+		header,
 		nil,
 		response,
 	)

--- a/invoice/invoice_test.go
+++ b/invoice/invoice_test.go
@@ -184,7 +184,6 @@ func TestExpire(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			var header *http.Header
 
 			apiRequesterMockObj.On(
 				"Call",
@@ -192,7 +191,7 @@ func TestExpire(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/invoices/123/expire!",
 				xendit.Opt.SecretKey,
-				header,
+				&http.Header{},
 				nil,
 				&xendit.Invoice{},
 			).Return(nil)

--- a/invoice/params.go
+++ b/invoice/params.go
@@ -77,5 +77,6 @@ func (p *GetAllParams) QueryString() string {
 
 // ExpireParams contains parameters for Expire
 type ExpireParams struct {
-	ID string `json:"id" validate:"required"`
+	ID        string `json:"id" validate:"required"`
+	ForUserID string `json:"-"`
 }


### PR DESCRIPTION
Currently, the SDK doesn't allow passing sub-account ID for expiring an invoice even though API permits. This PR allows passing of optional subaccount ID parameter for Invoice Expiry.