### PR TITLE
incorrect struct declaration on Invoice.go

### DIFF
--- a/invoice.go
+++ b/invoice.go
@@ -40,7 +40,7 @@ type Invoice struct {
 	SuccessRedirectURL        string                `json:"success_redirect_url,omitempty"`
 	FailureRedirectURL        string                `json:"failure_redirect_url,omitempty"`
 	Items                     []InvoiceItem         `json:"items,omitempty"`
-	FixedVA                   string                `json:"fixed_va,omitempty"`
+	FixedVA                   bool                  `json:"fixed_va,omitempty"`
 }
 
 // InvoiceBank is data that contained in `Invoice` at AvailableBanks


### PR DESCRIPTION
`FixedVa` field's data type doesn't match with the actual type returned from the API. it should be `bool` instead of `string`

```js
{
    "id": "61a471689f4902d08fbcd4cf",
    "external_id": "61a47168d9ffb776b9cbffc1",
    "user_id": "5f068bcd891e3a13988cf8e5",
    "status": "PENDING",
    ...
    "fixed_va": true // <----- api returns bool type of data for this particular field
}
```