### PR TITLE
feat(customers): add api version to customer params

### DIFF
--- a/customer/client.go
+++ b/customer/client.go
@@ -32,6 +32,9 @@ func (c *Client) CreateCustomerWithContext(ctx context.Context, data *CreateCust
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}
+	if data.APIVersion != "" {
+		header.Add("api-version", data.APIVersion)
+	}
 
 	err := c.APIRequester.Call(
 		ctx,

--- a/customer/params.go
+++ b/customer/params.go
@@ -9,6 +9,7 @@ import (
 // CreateCustomerParams contains parameters for CreateCustomer
 type CreateCustomerParams struct {
 	ForUserID    string                   `json:"-"`
+	APIVersion   string                   `json:"-"`
 	ReferenceID  string                   `json:"reference_id" validate:"required"`
 	MobileNumber string                   `json:"mobile_number,omitempty"`
 	Email        string                   `json:"email,omitempty"`


### PR DESCRIPTION
For merchants still using the old version, we'd want to allow them to use the go sdk and provide the api version for Customers API through params.
https://developers.xendit.co/api-reference/#customers

recreated PR from: https://github.com/xendit/xendit-go/pull/83