### PR TITLE
Fix race condition with APIRequesterWrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ go test ./invoice -run TestCreateInvoice
 #### Run integration tests
 
 ```sh
-SECRET_KEY=<your secret key> go run ./integration_test
+SECRET_KEY=<your secret key> go run -race ./integration_test
 ```
 
 ### Pre-commit


### PR DESCRIPTION
The initial call to GetAPIRequester (when apiRequesterWrapper.apiRequester
is nil) is now thread safe. Furthermore, changed the mutex protecting
the wrapper to a pointer. It's my understanding that mutex' aren't
safe to copy.

(Running the integration tests with -race confirmed this was an issue,
so this was added to the README)

(With or without this commit, I can't run all the integration tests, I guess because the way I have my test account setup / limited)