### PR TITLE
APIRequester.Call *http.Header -> http.Header

### DIFF
--- a/apirequester.go
+++ b/apirequester.go
@@ -13,7 +13,7 @@ import (
 // `body` is POST-requests' bodies if applicable.
 // `result` pointer to value which response string will be unmarshalled to.
 type APIRequester interface {
-	Call(ctx context.Context, method string, url string, secretKey string, header *http.Header, body interface{}, result interface{}) *Error
+	Call(ctx context.Context, method string, url string, secretKey string, header http.Header, body interface{}, result interface{}) *Error
 }
 
 // APIRequesterImplementation is the default implementation of APIRequester
@@ -24,7 +24,7 @@ type APIRequesterImplementation struct {
 // Call makes HTTP requests with JSON-format body.
 // `body` is POST-requests' bodies if applicable.
 // `result` pointer to value which response string will be unmarshalled to.
-func (a *APIRequesterImplementation) Call(ctx context.Context, method string, url string, secretKey string, header *http.Header, body interface{}, result interface{}) *Error {
+func (a *APIRequesterImplementation) Call(ctx context.Context, method string, url string, secretKey string, header http.Header, body interface{}, result interface{}) *Error {
 	reqBody := []byte("")
 	var req *http.Request
 	var err error
@@ -49,7 +49,7 @@ func (a *APIRequesterImplementation) Call(ctx context.Context, method string, ur
 	}
 
 	if header != nil {
-		req.Header = *header
+		req.Header = header
 	}
 	req.SetBasicAuth(secretKey, "")
 	req.Header.Set("Content-Type", "application/json")

--- a/balance/balance_test.go
+++ b/balance/balance_test.go
@@ -20,7 +20,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.Balance).Balance = 200000
@@ -56,7 +56,7 @@ func TestGet(t *testing.T) {
 				"GET",
 				xendit.Opt.XenditURL+"/balance?"+tC.data.QueryString(),
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				nil,
 				&xendit.Balance{},
 			).Return(nil)

--- a/balance/client.go
+++ b/balance/client.go
@@ -28,7 +28,7 @@ func (c *Client) GetWithContext(ctx context.Context, data *GetParams) (*xendit.B
 	}
 
 	response := &xendit.Balance{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/card/card_test.go
+++ b/card/card_test.go
@@ -25,7 +25,7 @@ type apiRequesterChargeMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterChargeMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterChargeMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	created, _ := time.Parse(time.RFC3339, "2020-02-02T00:00:00.000Z")
@@ -258,7 +258,7 @@ type apiRequesterRefundMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterRefundMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterRefundMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	created, _ := time.Parse(time.RFC3339, "2020-02-02T00:00:00.000Z")
@@ -349,7 +349,7 @@ type apiRequesterReverseAuthorizationMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterReverseAuthorizationMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterReverseAuthorizationMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	created, _ := time.Parse(time.RFC3339, "2020-02-02T00:00:00.000Z")

--- a/card/client.go
+++ b/card/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateChargeWithContext(ctx context.Context, data *CreateCharge
 	}
 
 	response := &xendit.CardCharge{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/card/client.go
+++ b/card/client.go
@@ -114,7 +114,7 @@ func (c *Client) CreateRefundWithContext(ctx context.Context, data *CreateRefund
 	}
 
 	response := &xendit.CardRefund{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.IdempotencyKey != "" {
 		header.Add("X-IDEMPOTENCY-KEY", data.IdempotencyKey)

--- a/cardlesscredit/cardlesscredit_test.go
+++ b/cardlesscredit/cardlesscredit_test.go
@@ -22,7 +22,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.CardlessCredit).RedirectURL = "https://google.com"
@@ -135,7 +135,7 @@ func TestCreatePayment(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/cardless-credit",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.CardlessCredit{},
 			).Return(nil)

--- a/cardlesscredit/client.go
+++ b/cardlesscredit/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreatePaymentWithContext(ctx context.Context, data *CreatePayme
 	}
 
 	response := &xendit.CardlessCredit{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	err := c.APIRequester.Call(
 		ctx,

--- a/customer/client.go
+++ b/customer/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateCustomerWithContext(ctx context.Context, data *CreateCust
 	}
 
 	response := &xendit.Customer{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/customer/customer_test.go
+++ b/customer/customer_test.go
@@ -22,7 +22,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.Customer).ID = "791ac956-397a-400f-9fda-4958894e61b5"
@@ -117,7 +117,7 @@ func TestCreateCustomer(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/customers",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.Customer{},
 			).Return(nil)
@@ -134,7 +134,7 @@ type apiRequesterMockGet struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockGet) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockGet) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[{

--- a/directdebit/directdebitpayment/client.go
+++ b/directdebit/directdebitpayment/client.go
@@ -81,7 +81,7 @@ func (c *Client) CreateDirectDebitPaymentWithContext(ctx context.Context, data *
 	}
 
 	response := &xendit.DirectDebitPayment{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -117,7 +117,7 @@ func (c *Client) ValidateOTPForDirectDebitPaymentWithContext(ctx context.Context
 	}
 
 	response := &xendit.DirectDebitPayment{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/directdebit/directdebitpayment/directdebitpayment_test.go
+++ b/directdebit/directdebitpayment/directdebitpayment_test.go
@@ -22,7 +22,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.DirectDebitPayment).ID = "ddpy-7e61b0a7-92f9-4762-a994-c2936306f44c"
@@ -227,7 +227,7 @@ func TestCreateDirectDebitPayment(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/direct_debits",
 				xendit.Opt.SecretKey,
-				&http.Header{"Idempotency-Key": []string{tC.data.IdempotencyKey}},
+				http.Header{"Idempotency-Key": []string{tC.data.IdempotencyKey}},
 				tC.data,
 				&xendit.DirectDebitPayment{},
 			).Return(nil)
@@ -244,7 +244,7 @@ type apiRequesterMockValidate struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockValidate) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockValidate) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.DirectDebitPayment).ID = "ddpy-7e61b0a7-92f9-4762-a994-c2936306f44c"
@@ -385,7 +385,7 @@ func TestValidateOTPForDirectDebitPayment(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/direct_debits/"+tC.data.DirectDebitID+"/validate_otp/",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.DirectDebitPayment{},
 			).Return(nil)
@@ -402,7 +402,7 @@ type apiRequesterMockGetByID struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockGetByID) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockGetByID) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	result.(*DirectDebitPaymentResponse).ID = "ddpy-7e61b0a7-92f9-4762-a994-c2936306f44c"
@@ -557,7 +557,7 @@ type apiRequesterMockGetByReferenceID struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockGetByReferenceID) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockGetByReferenceID) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[{

--- a/directdebit/linkedaccount/client.go
+++ b/directdebit/linkedaccount/client.go
@@ -27,7 +27,7 @@ func (c *Client) InitializeLinkedAccountTokenizationWithContext(ctx context.Cont
 	}
 
 	response := &xendit.InitializedLinkedAccount{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -61,7 +61,7 @@ func (c *Client) ValidateOTPForLinkedAccountWithContext(ctx context.Context, dat
 	}
 
 	response := &xendit.ValidatedLinkedAccount{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -124,7 +124,7 @@ func (c *Client) UnbindLinkedAccountTokenWithContext(ctx context.Context, data *
 	}
 
 	response := &xendit.UnbindedLinkedAccount{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/directdebit/linkedaccount/linkedaccount_test.go
+++ b/directdebit/linkedaccount/linkedaccount_test.go
@@ -22,7 +22,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.InitializedLinkedAccount).ID = "lat-f9dc34e7-153a-444e-b337-cd2599e7f670"
@@ -83,7 +83,7 @@ func TestInitializeLinkedAccountTokenization(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/linked_account_tokens/auth",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.InitializedLinkedAccount{},
 			).Return(nil)
@@ -100,7 +100,7 @@ type apiRequesterMockValidate struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockValidate) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockValidate) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.ValidatedLinkedAccount).ID = "lat-f9dc34e7-153a-444e-b337-cd2599e7f670"
@@ -153,7 +153,7 @@ func TestValidateOTPForLinkedAccount(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/linked_account_tokens/"+tC.data.LinkedAccountTokenID+"/validate_otp",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.ValidatedLinkedAccount{},
 			).Return(nil)
@@ -170,7 +170,7 @@ type apiRequesterMockRetrieve struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockRetrieve) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockRetrieve) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[{
@@ -255,7 +255,7 @@ type apiRequesterMockUnbind struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockUnbind) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockUnbind) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.UnbindedLinkedAccount).ID = "lat-f9dc34e7-153a-444e-b337-cd2599e7f670"
@@ -301,7 +301,7 @@ func TestUnbindLinkedAccountToken(t *testing.T) {
 				"DELETE",
 				xendit.Opt.XenditURL+"/linked_account_tokens/"+tC.data.LinkedAccountTokenID,
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.UnbindedLinkedAccount{},
 			).Return(nil)

--- a/directdebit/paymentmethod/client.go
+++ b/directdebit/paymentmethod/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreatePaymentMethodWithContext(ctx context.Context, data *Creat
 	}
 
 	response := &xendit.PaymentMethod{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/directdebit/paymentmethod/paymentmethod_test.go
+++ b/directdebit/paymentmethod/paymentmethod_test.go
@@ -22,7 +22,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.PaymentMethod).ID = "pm-ebb1c863-c7b5-4f20-b116-b3071b1d3aef"
@@ -113,7 +113,7 @@ func TestCreatePaymentMethod(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/payment_methods",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.PaymentMethod{},
 			).Return(nil)
@@ -130,7 +130,7 @@ type apiRequesterMockGet struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockGet) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockGet) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[{

--- a/disbursement/client.go
+++ b/disbursement/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateWithContext(ctx context.Context, data *CreateParams) (*xe
 	}
 
 	response := &xendit.Disbursement{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.IdempotencyKey != "" {
 		header.Add("X-IDEMPOTENCY-KEY", data.IdempotencyKey)
@@ -64,7 +64,7 @@ func (c *Client) GetByIDWithContext(ctx context.Context, data *GetByIDParams) (*
 	}
 
 	response := &xendit.Disbursement{}
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}
@@ -97,7 +97,7 @@ func (c *Client) GetByExternalIDWithContext(ctx context.Context, data *GetByExte
 	}
 
 	response := []xendit.Disbursement{}
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}
@@ -155,7 +155,7 @@ func (c *Client) CreateBatchWithContext(ctx context.Context, data *CreateBatchPa
 	}
 
 	response := &xendit.BatchDisbursement{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.IdempotencyKey != "" {
 		header.Add("X-IDEMPOTENCY-KEY", data.IdempotencyKey)

--- a/disbursement/disbursement_test.go
+++ b/disbursement/disbursement_test.go
@@ -24,7 +24,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.Disbursement).ID = "123"
@@ -93,7 +93,7 @@ func TestCreate(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/disbursements",
 				xendit.Opt.SecretKey,
-				mock.AnythingOfType("*http.Header"),
+				mock.AnythingOfType("http.Header"),
 				tC.data,
 				&xendit.Disbursement{},
 			).Return(nil)
@@ -149,7 +149,7 @@ func TestGetByID(t *testing.T) {
 				"GET",
 				xendit.Opt.XenditURL+"/disbursements/"+tC.data.DisbursementID,
 				xendit.Opt.SecretKey,
-				mock.AnythingOfType("*http.Header"),
+				mock.AnythingOfType("http.Header"),
 				nil,
 				&xendit.Disbursement{},
 			).Return(nil)
@@ -166,7 +166,7 @@ type apiRequesterGetByExternalIDMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetByExternalIDMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetByExternalIDMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[{
@@ -267,7 +267,7 @@ type apiRequesterGetAvailableBanksMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetAvailableBanksMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetAvailableBanksMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[
@@ -344,7 +344,7 @@ type apiRequesterBatchMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterBatchMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterBatchMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	date, _ := time.Parse(time.RFC3339, "2050-01-01T00:00:00.000Z")
@@ -420,7 +420,7 @@ func TestCreateBatch(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/batch_disbursements",
 				xendit.Opt.SecretKey,
-				mock.AnythingOfType("*http.Header"),
+				mock.AnythingOfType("http.Header"),
 				tC.data,
 				&xendit.BatchDisbursement{},
 			).Return(nil)

--- a/ewallet/client.go
+++ b/ewallet/client.go
@@ -103,7 +103,7 @@ func (c *Client) CreatePaymentWithContext(ctx context.Context, data *CreatePayme
 	}
 
 	response := &xendit.EWallet{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -176,7 +176,7 @@ func (c *Client) CreateEWalletChargeWithContext(ctx context.Context, data *Creat
 	}
 
 	response := &xendit.EWalletCharge{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -213,7 +213,7 @@ func (c *Client) GetEWalletChargeStatusWithContext(ctx context.Context, data *Ge
 	}
 
 	tempResponse := &EWalletChargeResponse{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/ewallet/ewallet_test.go
+++ b/ewallet/ewallet_test.go
@@ -21,7 +21,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.EWallet).EWalletType = xendit.EWalletTypeDANA
@@ -79,7 +79,7 @@ func TestCreatePayment(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/ewallets",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.EWallet{},
 			).Return(nil)
@@ -96,7 +96,7 @@ type apiRequesterMockGet struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockGet) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockGet) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	result.(*getPaymentStatusResponse).EWalletType = xendit.EWalletTypeDANA
@@ -166,7 +166,7 @@ type apiRequesterMockPostCharge struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockPostCharge) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockPostCharge) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.EWalletCharge).ID = "ewc_f3925450-5c54-4777-98c1-fcf22b0d1e1c"
@@ -267,7 +267,7 @@ func TestCreateEWalletCharge(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/ewallets/charges",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.EWalletCharge{},
 			).Return(nil)
@@ -284,7 +284,7 @@ type apiRequesterMockGetCharge struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMockGetCharge) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMockGetCharge) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	result.(*EWalletChargeResponse).ID = "ewc_f3925450-5c54-4777-98c1-fcf22b0d1e1c"

--- a/integration_test/main.go
+++ b/integration_test/main.go
@@ -11,7 +11,7 @@ func main() {
 	xendit.Opt.SecretKey = os.Getenv("SECRET_KEY")
 
 	wg := sync.WaitGroup{}
-	wg.Add(1)
+	wg.Add(13)
 	go func() {
 		balanceTest()
 		wg.Done()

--- a/integration_test/main.go
+++ b/integration_test/main.go
@@ -11,7 +11,7 @@ func main() {
 	xendit.Opt.SecretKey = os.Getenv("SECRET_KEY")
 
 	wg := sync.WaitGroup{}
-	wg.Add(13)
+	wg.Add(1)
 	go func() {
 		balanceTest()
 		wg.Done()

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateWithContext(ctx context.Context, data *CreateParams) (*xe
 	}
 
 	response := &xendit.Invoice{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -90,7 +90,7 @@ func (c *Client) ExpireWithContext(ctx context.Context, data *ExpireParams) (*xe
 	}
 
 	response := &xendit.Invoice{}
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}

--- a/invoice/client.go
+++ b/invoice/client.go
@@ -61,7 +61,7 @@ func (c *Client) GetWithContext(ctx context.Context, data *GetParams) (*xendit.I
 	}
 
 	response := &xendit.Invoice{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -126,7 +126,7 @@ func (c *Client) GetAllWithContext(ctx context.Context, data *GetAllParams) ([]x
 	response := []xendit.Invoice{}
 	var queryString string
 
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data != nil {
 		queryString = data.QueryString()

--- a/invoice/invoice_test.go
+++ b/invoice/invoice_test.go
@@ -24,7 +24,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	result.(*xendit.Invoice).ID = "123"
@@ -82,7 +82,7 @@ func TestCreate(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/v2/invoices",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.Invoice{},
 			).Return(nil)
@@ -129,7 +129,7 @@ func TestGet(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			var header *http.Header
+			var header http.Header
 
 			apiRequesterMockObj.On(
 				"Call",
@@ -191,7 +191,7 @@ func TestExpire(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/invoices/123/expire!",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				nil,
 				&xendit.Invoice{},
 			).Return(nil)
@@ -208,7 +208,7 @@ type apiRequesterGetAllMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetAllMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetAllMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[{

--- a/invoice/invoice_test.go
+++ b/invoice/invoice_test.go
@@ -136,7 +136,7 @@ func TestGet(t *testing.T) {
 				"GET",
 				xendit.Opt.XenditURL+"/v2/invoices/123",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				nil,
 				&xendit.Invoice{},
 			).Return(nil)

--- a/payout/payout_test.go
+++ b/payout/payout_test.go
@@ -23,7 +23,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	date, _ := time.Parse(time.RFC3339, "2050-01-01T00:00:00.000Z")

--- a/promotion/promotion_test.go
+++ b/promotion/promotion_test.go
@@ -25,7 +25,7 @@ type apiRequesterPromotionMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterPromotionMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterPromotionMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	mockTime, _ := time.Parse(time.RFC3339, "2020-02-02T00:00:00.000Z")
@@ -133,7 +133,7 @@ type apiRequesterGetPromotionsMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetPromotionsMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetPromotionsMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[
@@ -341,7 +341,7 @@ type apiRequesterDeletePromotionMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterDeletePromotionMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterDeletePromotionMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	result.(*xendit.PromotionDeletion).ID = "36ab1517-208a-4f22-b155-96fb101cb378"

--- a/qrcode/client.go
+++ b/qrcode/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateQRCodeWithContext(ctx context.Context, data *CreateQRCode
 	}
 
 	response := &xendit.QRCode{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
@@ -61,7 +61,7 @@ func (c *Client) GetQRCodeWithContext(ctx context.Context, data *GetQRCodeParams
 	}
 
 	response := &xendit.QRCode{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/qrcode/qrcode_test.go
+++ b/qrcode/qrcode_test.go
@@ -25,7 +25,7 @@ type apiRequesterQRCodeMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterQRCodeMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterQRCodeMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	mockTime, _ := time.Parse(time.RFC3339, "2020-02-02T00:00:00.000Z")
@@ -172,7 +172,7 @@ type apiRequesterGetQRCodePaymentsMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetQRCodePaymentsMock) Call(ctx context.Context, method string, path string, secretKey string, headers *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetQRCodePaymentsMock) Call(ctx context.Context, method string, path string, secretKey string, headers http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[

--- a/recurringpayment/client.go
+++ b/recurringpayment/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateWithContext(ctx context.Context, data *CreateParams) (*xe
 	}
 
 	response := &xendit.RecurringPayment{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/recurringpayment/recurringpayment_test.go
+++ b/recurringpayment/recurringpayment_test.go
@@ -23,7 +23,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	date, _ := time.Parse(time.RFC3339, "2050-01-01T00:00:00.000Z")

--- a/retailoutlet/client.go
+++ b/retailoutlet/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateFixedPaymentCodeWithContext(ctx context.Context, data *Cr
 	}
 
 	response := &xendit.RetailOutlet{}
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}
@@ -60,7 +60,7 @@ func (c *Client) GetFixedPaymentCodeWithContext(ctx context.Context, data *GetFi
 	}
 
 	response := &xendit.RetailOutlet{}
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}
@@ -93,7 +93,7 @@ func (c *Client) GetPaymentByFixedPaymentCodeWithContext(ctx context.Context, da
 	}
 
 	response := &xendit.RetailOutletPayments{}
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}
@@ -126,7 +126,7 @@ func (c *Client) UpdateFixedPaymentCodeWithContext(ctx context.Context, data *Up
 	}
 
 	response := &xendit.RetailOutlet{}
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}

--- a/retailoutlet/retailoutlet_test.go
+++ b/retailoutlet/retailoutlet_test.go
@@ -23,7 +23,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	expirationDate, _ := time.Parse(time.RFC3339, "2050-01-01T00:00:00.000Z")

--- a/retailoutlet/retailoutlet_test.go
+++ b/retailoutlet/retailoutlet_test.go
@@ -247,7 +247,7 @@ type apiRequesterGetPaymentByFixedPaymentCodeMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetPaymentByFixedPaymentCodeMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetPaymentByFixedPaymentCodeMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `{

--- a/transaction/client.go
+++ b/transaction/client.go
@@ -29,7 +29,7 @@ func (c *Client) GetTransactionnWithContext(ctx context.Context, data *GetTransa
 
 	response := &xendit.Transaction{}
 
-	header := &http.Header{}
+	header := http.Header{}
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)
 	}
@@ -62,7 +62,7 @@ func (c *Client) GetListTransactionWithContext(ctx context.Context, data *GetLis
 	}
 
 	response := &xendit.ListTransactions{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -25,7 +25,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `{
@@ -133,7 +133,7 @@ type apiRequesterGetListMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetListMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetListMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `{

--- a/virtualaccount/client.go
+++ b/virtualaccount/client.go
@@ -27,7 +27,7 @@ func (c *Client) CreateFixedVAWithContext(ctx context.Context, data *CreateFixed
 	}
 
 	response := &xendit.VirtualAccount{}
-	header := &http.Header{}
+	header := http.Header{}
 
 	if data.ForUserID != "" {
 		header.Add("for-user-id", data.ForUserID)

--- a/virtualaccount/virtualaccount_test.go
+++ b/virtualaccount/virtualaccount_test.go
@@ -24,7 +24,7 @@ type apiRequesterMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, header, params, result)
 
 	expirationDate, _ := time.Parse(time.RFC3339, "2051-01-19T17:00:00.000Z")
@@ -99,7 +99,7 @@ func TestCreateFixedVA(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/callback_virtual_accounts",
 				xendit.Opt.SecretKey,
-				&http.Header{},
+				http.Header{},
 				tC.data,
 				&xendit.VirtualAccount{},
 			).Return(nil)
@@ -155,7 +155,7 @@ func TestGetFixedVA(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			var header *http.Header
+			var header http.Header
 
 			apiRequesterMockObj.On(
 				"Call",
@@ -220,7 +220,7 @@ func TestUpdateFixedVA(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			var header *http.Header
+			var header http.Header
 
 			apiRequesterMockObj.On(
 				"Call",
@@ -245,7 +245,7 @@ type apiRequesterGetAvailableBanksMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetAvailableBanksMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetAvailableBanksMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	resultString := `[
@@ -314,7 +314,7 @@ type apiRequesterGetPaymentMock struct {
 	mock.Mock
 }
 
-func (m *apiRequesterGetPaymentMock) Call(ctx context.Context, method string, path string, secretKey string, header *http.Header, params interface{}, result interface{}) *xendit.Error {
+func (m *apiRequesterGetPaymentMock) Call(ctx context.Context, method string, path string, secretKey string, header http.Header, params interface{}, result interface{}) *xendit.Error {
 	m.Called(ctx, method, path, secretKey, nil, params, result)
 
 	transactionTimestamp, _ := time.Parse(time.RFC3339, "2020-01-01T17:00:00.000Z")


### PR DESCRIPTION
Since http.Header is just a map, and maps are already reference types
there's no point in an additional indirection (and a very tiny
performance cost to having it)

(My Go is a little rusty, so maybe I'm wrong about this?? But don't think so)