### PR TITLE
add for-user-id to virtual account requests

### DIFF
--- a/virtualaccount/client.go
+++ b/virtualaccount/client.go
@@ -61,13 +61,18 @@ func (c *Client) GetFixedVAWithContext(ctx context.Context, data *GetFixedVAPara
 	}
 
 	response := &xendit.VirtualAccount{}
+	header := http.Header{}
+
+	if data.ForUserID != "" {
+		header.Add("for-user-id", data.ForUserID)
+	}
 
 	err := c.APIRequester.Call(
 		ctx,
 		"GET",
 		fmt.Sprintf("%s/callback_virtual_accounts/%s", c.Opt.XenditURL, data.ID),
 		c.Opt.SecretKey,
-		nil,
+		header,
 		nil,
 		response,
 	)
@@ -90,13 +95,18 @@ func (c *Client) UpdateFixedWithContext(ctx context.Context, data *UpdateFixedVA
 	}
 
 	response := &xendit.VirtualAccount{}
+	header := http.Header{}
+
+	if data.ForUserID != "" {
+		header.Add("for-user-id", data.ForUserID)
+	}
 
 	err := c.APIRequester.Call(
 		ctx,
 		"PATCH",
 		fmt.Sprintf("%s/callback_virtual_accounts/%s", c.Opt.XenditURL, data.ID),
 		c.Opt.SecretKey,
-		nil,
+		header,
 		data,
 		response,
 	)
@@ -144,13 +154,18 @@ func (c *Client) GetPaymentWithContext(ctx context.Context, data *GetPaymentPara
 	}
 
 	response := &xendit.VirtualAccountPayment{}
+	header := http.Header{}
+
+	if data.ForUserID != "" {
+		header.Add("for-user-id", data.ForUserID)
+	}
 
 	err := c.APIRequester.Call(
 		ctx,
 		"GET",
 		fmt.Sprintf("%s/callback_virtual_account_payments/payment_id=%s", c.Opt.XenditURL, data.PaymentID),
 		c.Opt.SecretKey,
-		nil,
+		header,
 		nil,
 		response,
 	)

--- a/virtualaccount/params.go
+++ b/virtualaccount/params.go
@@ -19,11 +19,13 @@ type CreateFixedVAParams struct {
 
 // GetFixedVAParams contains parameters for GetFixedVA
 type GetFixedVAParams struct {
-	ID string `json:"id" validate:"required"`
+	ForUserID string `json:"-"`
+	ID        string `json:"id" validate:"required"`
 }
 
 // UpdateFixedVAParams contains parameters for UpdateFixedVA
 type UpdateFixedVAParams struct {
+	ForUserID       string     `json:"-"`
 	ID              string     `json:"-" validate:"required"`
 	IsSingleUse     *bool      `json:"is_single_use,omitempty"`
 	ExpirationDate  *time.Time `json:"expiration_date,omitempty"`
@@ -34,5 +36,6 @@ type UpdateFixedVAParams struct {
 
 // GetPaymentParams contains parameters for GetPayment
 type GetPaymentParams struct {
+	ForUserID string `json:"-"`
 	PaymentID string `json:"payment_id" validate:"required"`
 }

--- a/virtualaccount/virtualaccount_test.go
+++ b/virtualaccount/virtualaccount_test.go
@@ -155,15 +155,13 @@ func TestGetFixedVA(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			var header http.Header
-
 			apiRequesterMockObj.On(
 				"Call",
 				context.Background(),
 				"GET",
 				xendit.Opt.XenditURL+"/callback_virtual_accounts/"+tC.data.ID,
 				xendit.Opt.SecretKey,
-				header,
+				http.Header{},
 				nil,
 				&xendit.VirtualAccount{},
 			).Return(nil)
@@ -220,15 +218,13 @@ func TestUpdateFixedVA(t *testing.T) {
 
 	for _, tC := range testCases {
 		t.Run(tC.desc, func(t *testing.T) {
-			var header http.Header
-
 			apiRequesterMockObj.On(
 				"Call",
 				context.Background(),
 				"PATCH",
 				xendit.Opt.XenditURL+"/callback_virtual_accounts/"+tC.data.ID,
 				xendit.Opt.SecretKey,
-				header,
+				http.Header{},
 				tC.data,
 				&xendit.VirtualAccount{},
 			).Return(nil)


### PR DESCRIPTION
According to API doc, for-user-id is to be added to http header,
indicating the sub account to use
