### PR TITLE
fix: optional parameters for PMSv2 SDK

### DIFF
--- a/integration_test/ewallet.go
+++ b/integration_test/ewallet.go
@@ -90,7 +90,7 @@ func ewalletTest() {
 		Currency:       "IDR",
 		Amount:         10000,
 		CheckoutMethod: "TOKENIZED_PAYMENT",
-		ChannelCode:    "ID_DANA",
+		ChannelCode:    "ID_SHOPEEPAY",
 		ChannelProperties: map[string]string{
 			"success_redirect_url": "https://yourwebsite.com/order/123",
 			"failure_redirect_url": "https://yourwebsite.com/failure",
@@ -98,7 +98,7 @@ func ewalletTest() {
 		},
 		CaptureNow:      true,
 		CustomerID:      "d17cc20d-793b-4f9a-bd8c-2b1834b5b859",
-		PaymentMethodID: "pm-9da7fc6e-5cce-4bf5-827d-543fab8c2072",
+		PaymentMethodID: "pm-bf6cb1b6-e3ac-45ec-8fbf-f674c1a9974d",
 	}
 
 	createEWalletChargeTokenizedResponse, err := ewallet.CreateEWalletCharge(&createEWalletChargeTokenized)

--- a/integration_test/main.go
+++ b/integration_test/main.go
@@ -7,7 +7,7 @@ import (
 	"github.com/xendit/xendit-go"
 )
 
-//array of functions to test
+// array of functions to test
 var testFunctions = []func(){
 	balanceTest,
 	cardTest,

--- a/pmsv2/overthecounter/params.go
+++ b/pmsv2/overthecounter/params.go
@@ -32,24 +32,24 @@ const (
 
 type ChannelProperties struct {
 	CustomerName string     `json:"customer_name"`
-	PaymentCode  string     `json:"payment_code"`
+	PaymentCode  *string     `json:"payment_code,omitempty"`
 	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
 }
 
 type CreateMethod struct {
-	Amount            float64               `json:"amount"`
-	Currency          constant.CurrencyEnum `json:"currency"`
+	Amount            *float64               `json:"amount,omitempty"`
+	Currency          *constant.CurrencyEnum `json:"currency,omitempty"`
 	ChannelCode       ChannelCode           `json:"channel_code"`
 	ChannelProperties ChannelProperties     `json:"channel_properties"`
 }
 
 type MutableMethod struct {
-	Amount            int64                    `json:"amount"`
-	Currency          string                   `json:"currency"`
-	ChannelProperties MutableChannelProperties `json:"channel_properties"`
+	Amount            *float64                    `json:"amount,omitempty"`
+	Currency          *string                   `json:"currency,omitempty"`
+	ChannelProperties *MutableChannelProperties `json:"channel_properties,omitempty"`
 }
 
 type MutableChannelProperties struct {
-	CustomerName string     `json:"customer_name"`
+	CustomerName *string     `json:"customer_name,omitempty"`
 	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
 }

--- a/pmsv2/overthecounter/params.go
+++ b/pmsv2/overthecounter/params.go
@@ -32,24 +32,24 @@ const (
 
 type ChannelProperties struct {
 	CustomerName string     `json:"customer_name"`
-	PaymentCode  *string     `json:"payment_code,omitempty"`
+	PaymentCode  *string    `json:"payment_code,omitempty"`
 	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
 }
 
 type CreateMethod struct {
 	Amount            *float64               `json:"amount,omitempty"`
 	Currency          *constant.CurrencyEnum `json:"currency,omitempty"`
-	ChannelCode       ChannelCode           `json:"channel_code"`
-	ChannelProperties ChannelProperties     `json:"channel_properties"`
+	ChannelCode       ChannelCode            `json:"channel_code"`
+	ChannelProperties ChannelProperties      `json:"channel_properties"`
 }
 
 type MutableMethod struct {
-	Amount            *float64                    `json:"amount,omitempty"`
+	Amount            *float64                  `json:"amount,omitempty"`
 	Currency          *string                   `json:"currency,omitempty"`
 	ChannelProperties *MutableChannelProperties `json:"channel_properties,omitempty"`
 }
 
 type MutableChannelProperties struct {
-	CustomerName *string     `json:"customer_name,omitempty"`
+	CustomerName *string    `json:"customer_name,omitempty"`
 	ExpiresAt    *time.Time `json:"expires_at,omitempty"`
 }

--- a/pmsv2/params.go
+++ b/pmsv2/params.go
@@ -16,7 +16,7 @@ type CreatePaymentMethodParams struct {
 	Type               constant.PaymentMethodTypeEnum `json:"type"`
 	Country            constant.CountryEnum           `json:"country,omitempty"`
 	CustomerID         *string                        `json:"customer_id,omitempty"`
-	ReferenceID        *string                         `json:"reference_id,omitempty"`
+	ReferenceID        *string                        `json:"reference_id,omitempty"`
 	Reusability        constant.ReusabilityEnum       `json:"reusability"`
 	Description        *string                        `json:"description,omitempty"`
 	Metadata           map[string]interface{}         `json:"metadata,omitempty"`
@@ -70,12 +70,12 @@ type RetrieveAllPaymentMethodsRequest struct {
 }
 
 type UpdateRequest struct {
-	ReferenceID   *string                           `json:"reference_id,omitempty"`
+	ReferenceID    *string                           `json:"reference_id,omitempty"`
 	Description    *string                           `json:"description,omitempty"`
 	Status         *constant.PaymentMethodStatusEnum `json:"status,omitempty"`
 	Reusability    *constant.ReusabilityEnum         `json:"reusability,omitempty"`
-	OverTheCounter *overthecounter.MutableMethod    `json:"over_the_counter,omitempty"`
-	VirtualAccount *virtualaccount.MutableMethod    `json:"virtual_account,omitempty"`
+	OverTheCounter *overthecounter.MutableMethod     `json:"over_the_counter,omitempty"`
+	VirtualAccount *virtualaccount.MutableMethod     `json:"virtual_account,omitempty"`
 
 	ID string `json:"-"`
 

--- a/pmsv2/params.go
+++ b/pmsv2/params.go
@@ -16,7 +16,7 @@ type CreatePaymentMethodParams struct {
 	Type               constant.PaymentMethodTypeEnum `json:"type"`
 	Country            constant.CountryEnum           `json:"country,omitempty"`
 	CustomerID         *string                        `json:"customer_id,omitempty"`
-	ReferenceID        string                         `json:"reference_id,omitempty"`
+	ReferenceID        *string                         `json:"reference_id,omitempty"`
 	Reusability        constant.ReusabilityEnum       `json:"reusability"`
 	Description        *string                        `json:"description,omitempty"`
 	Metadata           map[string]interface{}         `json:"metadata,omitempty"`
@@ -70,12 +70,12 @@ type RetrieveAllPaymentMethodsRequest struct {
 }
 
 type UpdateRequest struct {
-	ReferenceID    string                           `json:"reference_id"`
-	Description    string                           `json:"description"`
-	Status         constant.PaymentMethodStatusEnum `json:"status"`
-	Reusability    constant.ReusabilityEnum         `json:"reusability"`
-	OverTheCounter *overthecounter.MutableMethod    `json:"over_the_counter"`
-	VirtualAccount *virtualaccount.MutableMethod    `json:"virtual_account"`
+	ReferenceID   *string                           `json:"reference_id,omitempty"`
+	Description    *string                           `json:"description,omitempty"`
+	Status         *constant.PaymentMethodStatusEnum `json:"status,omitempty"`
+	Reusability    *constant.ReusabilityEnum         `json:"reusability,omitempty"`
+	OverTheCounter *overthecounter.MutableMethod    `json:"over_the_counter,omitempty"`
+	VirtualAccount *virtualaccount.MutableMethod    `json:"virtual_account,omitempty"`
 
 	ID string `json:"-"`
 

--- a/pmsv2/payment_method_test.go
+++ b/pmsv2/payment_method_test.go
@@ -44,6 +44,8 @@ func TestCreatePaymentMethod(t *testing.T) {
 	apiRequesterMockObj := new(apiRequesterMock)
 	initTesting(apiRequesterMockObj)
 
+	referenceID := "reference_id"
+
 	testCases := []struct {
 		desc        string
 		data        *CreatePaymentMethodParams
@@ -56,7 +58,7 @@ func TestCreatePaymentMethod(t *testing.T) {
 				Type:        constant.PaymentMethodTypeEwallet,
 				Country:     constant.CountryPH,
 				CustomerID:  nil,
-				ReferenceID: "reference_id",
+				ReferenceID: &referenceID,
 				Reusability: constant.ReusabilityMultipleUse,
 				Description: nil,
 				Metadata:    nil,
@@ -329,6 +331,7 @@ func TestUpdatePaymentMethod(t *testing.T) {
 	apiRequesterMockObj := new(apiRequesterMock)
 	initTesting(apiRequesterMockObj)
 
+	status := constant.Active
 	testCases := []struct {
 		desc        string
 		data        *UpdateRequest
@@ -339,7 +342,7 @@ func TestUpdatePaymentMethod(t *testing.T) {
 			desc: "should update",
 			data: &UpdateRequest{
 				ID:     "id",
-				Status: constant.Active,
+				Status: &status,
 			},
 			expectedRes: &xendit.PaymentMethodResponse{
 				Type:        constant.PaymentMethodTypeEwallet,

--- a/pmsv2/qrcode/params.go
+++ b/pmsv2/qrcode/params.go
@@ -26,8 +26,8 @@ type ChannelProperties struct {
 }
 
 type CreateMethod struct {
-	Amount            float64               `json:"amount"`
-	Currency          constant.CurrencyEnum `json:"currency"`
+	Amount            *float64               `json:"amount,omitempty"`
+	Currency          *constant.CurrencyEnum `json:"currency,omitempty"`
 	ChannelCode       ChannelCode           `json:"channel_code"`
 	ChannelProperties ChannelProperties     `json:"channel_properties"`
 }

--- a/pmsv2/qrcode/params.go
+++ b/pmsv2/qrcode/params.go
@@ -28,6 +28,6 @@ type ChannelProperties struct {
 type CreateMethod struct {
 	Amount            *float64               `json:"amount,omitempty"`
 	Currency          *constant.CurrencyEnum `json:"currency,omitempty"`
-	ChannelCode       ChannelCode           `json:"channel_code"`
-	ChannelProperties ChannelProperties     `json:"channel_properties"`
+	ChannelCode       ChannelCode            `json:"channel_code"`
+	ChannelProperties ChannelProperties      `json:"channel_properties"`
 }

--- a/pmsv2/virtualaccount/params.go
+++ b/pmsv2/virtualaccount/params.go
@@ -22,28 +22,28 @@ const (
 
 type ChannelProperties struct {
 	CustomerName         string     `json:"customer_name"`
-	VirtualAccountNumber *string    `json:"virtual_account_number"`
-	ExpiresAt            *time.Time `json:"expires_at"`
-	SuggestedAmount      float64    `json:"suggested_amount,omitempty"`
+	VirtualAccountNumber *string    `json:"virtual_account_number,omitempty"`
+	ExpiresAt            *time.Time `json:"expires_at,omitempty"`
+	SuggestedAmount      *float64    `json:"suggested_amount,omitempty"`
 }
 
 type CreateMethod struct {
-	Amount            float64               `json:"amount"`
-	MinimumAmount     float64               `json:"min_amount,omitempty"`
-	MaximumAmount     float64               `json:"max_amount,omitempty"`
-	Currency          constant.CurrencyEnum `json:"currency"`
+	Amount            *float64               `json:"amount,omitempty"`
+	MinimumAmount     *float64               `json:"min_amount,omitempty"`
+	MaximumAmount     *float64               `json:"max_amount,omitempty"`
+	Currency          *constant.CurrencyEnum `json:"currency,omitempty"`
 	ChannelCode       ChannelCode           `json:"channel_code"`
 	ChannelProperties ChannelProperties     `json:"channel_properties"`
 }
 
 type MutableMethod struct {
-	Amount            int64                    `json:"amount"`
-	MinimumAmount     int64                    `json:"min_amount"`
-	MaximumAmount     int64                    `json:"max_amount"`
-	ChannelProperties MutableChannelProperties `json:"channel_properties"`
+	Amount            *float64                    `json:"amount,omitempty"`
+	MinimumAmount     *float64                    `json:"min_amount,omitempty"`
+	MaximumAmount     *float64                    `json:"max_amount,omitempty"`
+	ChannelProperties *MutableChannelProperties `json:"channel_properties,omitempty"`
 }
 
 type MutableChannelProperties struct {
-	ExpiresAt       *time.Time `json:"expires_at"`
-	SuggestedAmount int64      `json:"suggested_amount"`
+	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
+	SuggestedAmount *int64      `json:"suggested_amount,omitempty"`
 }

--- a/pmsv2/virtualaccount/params.go
+++ b/pmsv2/virtualaccount/params.go
@@ -24,7 +24,7 @@ type ChannelProperties struct {
 	CustomerName         string     `json:"customer_name"`
 	VirtualAccountNumber *string    `json:"virtual_account_number,omitempty"`
 	ExpiresAt            *time.Time `json:"expires_at,omitempty"`
-	SuggestedAmount      *float64    `json:"suggested_amount,omitempty"`
+	SuggestedAmount      *float64   `json:"suggested_amount,omitempty"`
 }
 
 type CreateMethod struct {
@@ -32,18 +32,18 @@ type CreateMethod struct {
 	MinimumAmount     *float64               `json:"min_amount,omitempty"`
 	MaximumAmount     *float64               `json:"max_amount,omitempty"`
 	Currency          *constant.CurrencyEnum `json:"currency,omitempty"`
-	ChannelCode       ChannelCode           `json:"channel_code"`
-	ChannelProperties ChannelProperties     `json:"channel_properties"`
+	ChannelCode       ChannelCode            `json:"channel_code"`
+	ChannelProperties ChannelProperties      `json:"channel_properties"`
 }
 
 type MutableMethod struct {
-	Amount            *float64                    `json:"amount,omitempty"`
-	MinimumAmount     *float64                    `json:"min_amount,omitempty"`
-	MaximumAmount     *float64                    `json:"max_amount,omitempty"`
+	Amount            *float64                  `json:"amount,omitempty"`
+	MinimumAmount     *float64                  `json:"min_amount,omitempty"`
+	MaximumAmount     *float64                  `json:"max_amount,omitempty"`
 	ChannelProperties *MutableChannelProperties `json:"channel_properties,omitempty"`
 }
 
 type MutableChannelProperties struct {
 	ExpiresAt       *time.Time `json:"expires_at,omitempty"`
-	SuggestedAmount *int64      `json:"suggested_amount,omitempty"`
+	SuggestedAmount *int64     `json:"suggested_amount,omitempty"`
 }


### PR DESCRIPTION
Changes:

Update the PMSv2 SDK parameters based on the docs below as reference
https://developers.xendit.co/api-reference/#create-payment-method

Other discrepancies not visible here:
`card_information.cvv` is not in the docs, but should be included
`min_amount` and `max_amount` are not in the Update VA PM docs but should be included

