### PR TITLE
Expose fields on get available banks (VA) endpoint

### DIFF
--- a/virtualaccount.go
+++ b/virtualaccount.go
@@ -27,8 +27,11 @@ type VirtualAccount struct {
 
 // VirtualAccountBank contains data from Xendit's API response of Get Virtual Account Banks.
 type VirtualAccountBank struct {
-	Name string `json:"name"`
-	Code string `json:"code"`
+	Name        string `json:"name"`
+	Code        string `json:"code"`
+	Country     string `json:"country"`
+	Currency    string `json:"currency"`
+	IsActivated bool   `json:"is_activated"`
 }
 
 // VirtualAccountPayment contains data from Xendit's API response of Get Fixed Virtual Account Payment.


### PR DESCRIPTION
Today we found that your [Get Virtual Account Banks](https://developers.xendit.co/api-reference/#get-virtual-account-banks) response includes inactive banks. To fix the issue on our side, we need some fields to do post-process after retrieving the response.

In this PR, we created all missing fields based on Get Virtual Account Bank's responses

It would be better if the client could filter banks based on query string params