### PR TITLE
Add optional settlement information on transaction object

### DIFF
--- a/transaction.go
+++ b/transaction.go
@@ -6,22 +6,24 @@ import "time"
 // For more details see https://developers.xendit.co/api-reference/#transactions.
 // For documentation of subpackage payout, checkout https://pkg.go.dev/github.com/xendit/xendit-go/transaction
 type Transaction struct {
-	ID                string         `json:"id"`
-	ProductID         string         `json:"product_id"`
-	Type              string         `json:"type"`
-	ChannelCode       string         `json:"channel_code,omitempty"`
-	ReferenceID       string         `json:"reference_id"`
-	AccountIdentifier string         `json:"account_identifier,omitempty"`
-	Currency          string         `json:"currency,omitempty"`
-	Amount            float64        `json:"amount"`
-	NetAmount         float64        `json:"net_amount"`
-	Cashflow          string         `json:"cashflow"`
-	Status            string         `json:"status"`
-	ChannelCategory   string         `json:"channel_category"`
-	BusinessID        string         `json:"business_id"`
-	Created           *time.Time     `json:"created"`
-	Updated           *time.Time     `json:"updated"`
-	Fee               TransactionFee `json:"fee"`
+	ID                      string         `json:"id"`
+	ProductID               string         `json:"product_id"`
+	Type                    string         `json:"type"`
+	ChannelCode             string         `json:"channel_code,omitempty"`
+	ReferenceID             string         `json:"reference_id"`
+	AccountIdentifier       string         `json:"account_identifier,omitempty"`
+	Currency                string         `json:"currency,omitempty"`
+	Amount                  float64        `json:"amount"`
+	NetAmount               float64        `json:"net_amount"`
+	Cashflow                string         `json:"cashflow"`
+	Status                  string         `json:"status"`
+	ChannelCategory         string         `json:"channel_category"`
+	BusinessID              string         `json:"business_id"`
+	SettlementStatus        string         `json:"settlement_status,omitempty"`
+	EstimatedSettlementTime *time.Time     `json:"estimated_settlement_time,omitempty"`
+	Created                 *time.Time     `json:"created"`
+	Updated                 *time.Time     `json:"updated"`
+	Fee                     TransactionFee `json:"fee"`
 }
 
 type TransactionFee struct {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -151,6 +151,8 @@ func (m *apiRequesterGetListMock) Call(ctx context.Context, method string, path 
 				"currency": "IDR",
 				"amount": 1,
 				"cashflow": "MONEY_IN",
+				"settlement_status" : "PENDING",
+				"estimated_settlement_time" : "2021-06-26T04:03:02.123Z",
 				"business_id": "5fc9f5b246f820517e38c84d",
 				"created": "2021-06-23T02:42:15.601Z",
 				"updated": "2021-06-23T02:42:15.601Z"
@@ -196,6 +198,8 @@ func TestGetListTransaction(t *testing.T) {
 	created2 := time.Date(2021, 6, 23, 2, 39, 23, 176000000, time.UTC)
 	updated2 := time.Date(2021, 6, 23, 2, 39, 23, 176000000, time.UTC)
 
+	estimatedSettlement := time.Date(2021, 6, 26, 4, 3, 2, 123000000, time.UTC)
+
 	testCases := []struct {
 		desc        string
 		data        *transaction.GetListTransactionParams
@@ -209,20 +213,22 @@ func TestGetListTransaction(t *testing.T) {
 				HasMore: true,
 				Data: []xendit.Transaction{
 					{
-						ID:                "txn_13dd178d-41fa-40b7-8fd3-f83675d6f413",
-						ProductID:         "d290f1ee-6c54-4b01-90e6-d701748f0701",
-						Type:              "PAYMENT",
-						Status:            "SUCCESS",
-						ChannelCategory:   "RETAIL_OUTLET",
-						ChannelCode:       "ALFAMART",
-						ReferenceID:       "ref23244",
-						AccountIdentifier: "",
-						Currency:          "IDR",
-						Amount:            1,
-						Cashflow:          "MONEY_IN",
-						BusinessID:        "5fc9f5b246f820517e38c84d",
-						Created:           &created,
-						Updated:           &updated,
+						ID:                      "txn_13dd178d-41fa-40b7-8fd3-f83675d6f413",
+						ProductID:               "d290f1ee-6c54-4b01-90e6-d701748f0701",
+						Type:                    "PAYMENT",
+						Status:                  "SUCCESS",
+						ChannelCategory:         "RETAIL_OUTLET",
+						ChannelCode:             "ALFAMART",
+						ReferenceID:             "ref23244",
+						AccountIdentifier:       "",
+						Currency:                "IDR",
+						Amount:                  1,
+						Cashflow:                "MONEY_IN",
+						BusinessID:              "5fc9f5b246f820517e38c84d",
+						SettlementStatus:        "PENDING",
+						EstimatedSettlementTime: &estimatedSettlement,
+						Created:                 &created,
+						Updated:                 &updated,
 					},
 					{
 						ID:                "txn_a765a3f0-34c0-41ee-8686-bca11835ebdc",


### PR DESCRIPTION
## Overview 
https://github.com/xendit/xendit-go/issues/102 

## Changes
the [transaction object ](https://developers.xendit.co/api-reference/#transaction-object) document mentioned that the it should contains `settlement_status` and `estimated_settlement_time` data but it's currently missing from the go sdk. so im adding them to the transaction object as optional field.  
<img width="400" alt="image" src="https://github.com/xendit/xendit-go/assets/11547662/21a4fd45-b1af-4543-995c-6f4b7119f988">

