### PR TITLE
Add idempotency key parameter to payout creation

### DIFF
--- a/payout/client.go
+++ b/payout/client.go
@@ -29,7 +29,7 @@ func (c *Client) CreateWithContext(ctx context.Context, data *CreateParams) (*xe
 	response := &xendit.Payout{}
 	header := http.Header{}
 	if data.IdempotencyKey != "" {
-		header.Add("X-IDEMPOTENCY-KEY", data.IdempotencyKey)
+		header.Add("x-idempotency-key", data.IdempotencyKey)
 	}
 
 	err := c.APIRequester.Call(

--- a/payout/client.go
+++ b/payout/client.go
@@ -3,6 +3,7 @@ package payout
 import (
 	"context"
 	"fmt"
+	"net/http"
 
 	"github.com/xendit/xendit-go"
 	"github.com/xendit/xendit-go/utils/validator"
@@ -26,13 +27,17 @@ func (c *Client) CreateWithContext(ctx context.Context, data *CreateParams) (*xe
 	}
 
 	response := &xendit.Payout{}
+	header := http.Header{}
+	if data.IdempotencyKey != "" {
+		header.Add("X-IDEMPOTENCY-KEY", data.IdempotencyKey)
+	}
 
 	err := c.APIRequester.Call(
 		ctx,
 		"POST",
 		fmt.Sprintf("%s/payouts", c.Opt.XenditURL),
 		c.Opt.SecretKey,
-		nil,
+		header,
 		data,
 		response,
 	)

--- a/payout/params.go
+++ b/payout/params.go
@@ -2,9 +2,10 @@ package payout
 
 // CreateParams contains parameters for Create
 type CreateParams struct {
-	ExternalID string  `json:"external_id" validate:"required"`
-	Amount     float64 `json:"amount" validate:"required"`
-	Email      string  `json:"email" validate:"required"`
+	IdempotencyKey string  `json:"-"`
+	ExternalID     string  `json:"external_id" validate:"required"`
+	Amount         float64 `json:"amount" validate:"required"`
+	Email          string  `json:"email" validate:"required"`
 }
 
 // GetParams contains parameters for Get

--- a/payout/payout_test.go
+++ b/payout/payout_test.go
@@ -55,6 +55,7 @@ func TestCreatePayout(t *testing.T) {
 		{
 			desc: "should create an payout",
 			data: &payout.CreateParams{
+				IdempotencyKey: "unique-idempotency-key",
 				ExternalID: "payout-external-id",
 				Amount:     200000,
 				Email:      "customer@customer.com",
@@ -89,7 +90,7 @@ func TestCreatePayout(t *testing.T) {
 				"POST",
 				xendit.Opt.XenditURL+"/payouts",
 				xendit.Opt.SecretKey,
-				nil,
+				mock.Anything,
 				tC.data,
 				&xendit.Payout{},
 			).Return(nil)


### PR DESCRIPTION
## Overview 
context : payout link creation
I would like to avoid creating multiple payout links for the same requests so im adding idempotency key parameter to payout client. 

## What changed 
im reffering to disbursement creation on how to add idempotency key headder. 
https://github.com/xendit/xendit-go/blob/8a3d6f222ccdc8ede49b786e7c41d8ed111a9543/disbursement/client.go#L30-L34