### PR TITLE
disbursement-callback-struct

### DIFF
--- a/disbursement/event.go
+++ b/disbursement/event.go
@@ -1,0 +1,16 @@
+package disbursement
+
+type DisbursementCallback struct {
+	ID                      string  `json:"id"`
+	Created                 string  `json:"created"`
+	Updated                 string  `json:"updated"`
+	ExternalID              string  `json:"external_id"`
+	UserID                  string  `json:"user_id"`
+	Amount                  float64 `json:"amount"`
+	BankCode                string  `json:"bank_code"`
+	AccountHolderName       string  `json:"account_holder_name"`
+	DisbursementDescription string  `json:"disbursement_description"`
+	Status                  string  `json:"status"`
+	FailureCode             string  `json:"failure_code,omitempty"`
+	IsInstant               bool    `json:"is_instant,omitempty"`
+}

--- a/disbursement/event_test.go
+++ b/disbursement/event_test.go
@@ -1,0 +1,83 @@
+package disbursement_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/xendit/xendit-go/disbursement"
+)
+
+func TestPayload_Completed(t *testing.T) {
+	payload := `{
+	    "id": "57e214ba82b034c325e84d6e",
+	    "created": "2021-07-10T08:15:03.404Z",
+	    "updated": "2021-07-10T08:15:03.404Z",
+	    "external_id": "disbursement_123124123",
+	    "user_id": "57c5aa7a36e3b6a709b6e148",
+	    "amount": 150000,
+	    "bank_code": "BCA",
+	    "account_holder_name": "MICHAEL CHEN",
+	    "disbursement_description": "Refund for shoes",
+	    "status": "COMPLETED",
+	    "is_instant": true
+	}`
+
+	expectedPayload := disbursement.DisbursementCallback{
+		ID:                      "57e214ba82b034c325e84d6e",
+		Created:                 "2021-07-10T08:15:03.404Z",
+		Updated:                 "2021-07-10T08:15:03.404Z",
+		ExternalID:              "disbursement_123124123",
+		UserID:                  "57c5aa7a36e3b6a709b6e148",
+		Amount:                  150000,
+		BankCode:                "BCA",
+		AccountHolderName:       "MICHAEL CHEN",
+		DisbursementDescription: "Refund for shoes",
+		Status:                  "COMPLETED",
+		IsInstant:               true,
+	}
+
+	var actualPayload disbursement.DisbursementCallback
+	err := json.Unmarshal([]byte(payload), &actualPayload)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedPayload, actualPayload)
+}
+
+func TestPayload_Failed(t *testing.T) {
+	payload := `{
+	    "id": "57e214ba82b034c325e84d6e",
+	    "created": "2021-07-10T08:15:03.404Z",
+	    "updated": "2021-07-10T08:15:03.404Z",
+	    "external_id": "disbursement_123124123",
+	    "user_id": "57c5aa7a36e3b6a709b6e148",
+	    "amount": 150000,
+	    "bank_code": "BCA",
+	    "account_holder_name": "MICHAEL CHEN",
+	    "disbursement_description": "Refund for shoes",
+	    "status": "FAILED",
+	    "failure_code": "INVALID_DESTINATION",
+	    "is_instant": true
+	}`
+
+	expectedPayload := disbursement.DisbursementCallback{
+		ID:                      "57e214ba82b034c325e84d6e",
+		Created:                 "2021-07-10T08:15:03.404Z",
+		Updated:                 "2021-07-10T08:15:03.404Z",
+		ExternalID:              "disbursement_123124123",
+		UserID:                  "57c5aa7a36e3b6a709b6e148",
+		Amount:                  150000,
+		BankCode:                "BCA",
+		AccountHolderName:       "MICHAEL CHEN",
+		DisbursementDescription: "Refund for shoes",
+		Status:                  "FAILED",
+		FailureCode:             "INVALID_DESTINATION",
+		IsInstant:               true,
+	}
+
+	var actualPayload disbursement.DisbursementCallback
+	err := json.Unmarshal([]byte(payload), &actualPayload)
+	assert.NoError(t, err)
+
+	assert.Equal(t, expectedPayload, actualPayload)
+}


### PR DESCRIPTION
## Overview
i would like to have a struct to parse the incoming event when payout link(disbursement) has been paid.
https://developers.xendit.co/api-reference/#disbursement-callback

## What changed
i added `DisbursmentCallback` struct on disbursement package and create the test using sample payload from the documentation. 
