### PR TITLE
RFC-27: Automated Dependency Updates (Add Dependabot Config)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,29 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
 version: 2
+registries:
+  xendit-ecr:
+    url: https://420361828844.dkr.ecr.ap-southeast-1.amazonaws.com
+    type: docker-registry
+    username: ${{secrets.ECR_AWS_ACCESS_KEY_ID}}
+    password: ${{secrets.ECR_AWS_SECRET_ACCESS_KEY}}
 updates:
-  - package-ecosystem: "gomod" # See documentation for possible values
-    directory: "/" # Location of package manifests
+  - package-ecosystem: 'gomod' # See documentation for possible values
+    directory: '/' # Location of package manifests
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    open-pull-requests-limit: 10
+    commit-message:
+      prefix: fix
+      prefix-development: chore
+      include: scope
+  - package-ecosystem: 'docker'
+    directory: '/'
+    registries:
+      - xendit-ecr
+    schedule:
+      interval: 'daily'
+    open-pull-requests-limit: 10


### PR DESCRIPTION

This dependabot config is used for updating both your `npm/gomod` package and `Dockerfile`. You can adjust the settings to meet your requirement.

Aside from dependabot config, if you want your repo to have additional auto approve and merge the PR from dependabot, you can see and follow the steps to implement on the [RFC-27 docs](https://docs.google.com/document/d/1FjyGF0_X4Aibn1sKVmBeaINZ2C2PKdBjWit1EDvTZUc/edit).

## How this change was made
This PR is made by copying the standard configs available on:

1. [Gomod](https://github.com/xendit/github-repo-automation/blob/main/src/vulnerabilities/prs-file-contents/dependabot/gomod/dependabot.yml)

2. [npm](https://github.com/xendit/github-repo-automation/blob/main/src/vulnerabilities/prs-file-contents/dependabot/npm/dependabot.yml)

If you have any previous config, you would probably need to adjust the PR further.


<sub>This PR was generated using [turbolift](https://github.com/Skyscanner/turbolift).</sub>